### PR TITLE
Add data for the number of files (14343) in the home directory of Keady's VM to the file Day9_File_Counts.md

### DIFF
--- a/Day9_File_Counts.md
+++ b/Day9_File_Counts.md
@@ -21,7 +21,7 @@ Task: submit a PR with the number of files contained in your home directory
 | Hunter   |            |
 | Jack     |            |
 | Justin   |            |
-| Keady    |            |
+| Keady    |   14343    |
 | Lala     |            |
 | Leon     |            |
 | Luke     |            |


### PR DESCRIPTION
Add data for the number of files (14343) in the home directory of Keady's VM to the file Day9_File_Counts.md

This commit alters one file - Day9_File_Counts.md. The file now contains the data for the current number of files in the home directory of Keady, which is 14343. This change is being made because the data was previously missing from the file.