### PR TITLE
Add my home directory file count (21874) to Day9_File_Counts.md

### DIFF
--- a/Day9_File_Counts.md
+++ b/Day9_File_Counts.md
@@ -26,7 +26,7 @@ Task: submit a PR with the number of files contained in your home directory
 | Leon     |            |
 | Luke     |            |
 | Manti    |            |
-| Mary     |            |
+| Mary     |   21874    |
 | MJ       |            |
 | Nikolai  |            |
 | Njeri    |            |


### PR DESCRIPTION
For the Day 9 exercise, I counted all files in my home directory using 'find ~ -type f | wc -l' and I got a result of 21874 files.
I've added this count next to my name in the table.