### PR TITLE
This bug where anything above 2 will fail

### DIFF
--- a/circle_area.py
+++ b/circle_area.py
@@ -9,4 +9,4 @@ def calculate_area(radius):
         float: The area of the circle.
     """
     pi = 3.14
-    return pi * radius * 2
+    return pi * radius ** 2

--- a/circle_area.py
+++ b/circle_area.py
@@ -9,4 +9,4 @@ def calculate_area(radius):
         float: The area of the circle.
     """
     pi = 3.14
-    return 2 * pi * radius
+    return pi * radius * 2

--- a/test_circle_area.py
+++ b/test_circle_area.py
@@ -3,7 +3,7 @@ from circle_area import calculate_area
 
 class TestCircleArea(unittest.TestCase):
     def test_radius_two(self):
-        self.assertAlmostEqual(calculate_area(2), 12.56)
+        self.assertAlmostEqual(calculate_area(3), 28.26)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The bug was caused by the formula multipling 2 directly to pi and the radius. The true formula is pi multiplied by the raidus to the power of 2 and as the power of 2 is just multiply by 2 this works for the instance were radius is 2. To fix this we directly fix the formula which will cause the calculation to be correct there by fixing the issue.

The new test case will show that any radius other than 2 will fail as 2*radius is not the same as radius**2. So a bug was found when radius was 3. The current change to circle_radius.py shows the correct fix that passes both cases where radius is 2 or another radius.