### PR TITLE
Area calculation is wrong for any radius other than 2

### DIFF
--- a/circle_area.py
+++ b/circle_area.py
@@ -9,4 +9,4 @@ def calculate_area(radius):
         float: The area of the circle.
     """
     pi = 3.14
-    return 2 * pi * radius
+    return pi * radius ** 2

--- a/test_circle_area.py
+++ b/test_circle_area.py
@@ -4,6 +4,7 @@ from circle_area import calculate_area
 class TestCircleArea(unittest.TestCase):
     def test_radius_two(self):
         self.assertAlmostEqual(calculate_area(2), 12.56)
-
+    def test_radius_three(self):
+        self.assertAlmostEqual(calculate_area(3), 28.26)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The bug was caused by the formula multiplying 2 directly by pi and the radius. The correct formula is pi multiplied by the radius to the power of 2. Since powering by 2 is equivalent to multiplying by 2 only when the radius is 2, the original formula worked only in that specific instance. To fix this, we directly corrected the formula, ensuring the calculation is accurate and resolving the issue.

The new test case demonstrates that any radius other than 2 will fail because 2 * radius is not equivalent to radius ** 2 . For example, a bug was identified when the radius was 3. The current change to circle_radius.py provides the correct fix, passing both cases where the radius is 2 and other radii.

Issue #42