### PR TITLE
Temperature conversion #26 fix

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rewrap.wrappingColumn": 72
+}

--- a/temperature_utils.py
+++ b/temperature_utils.py
@@ -1,4 +1,4 @@
-def to_fahrenheit(celsius):
+def to_fahrenheit(celsius: float) -> float:
     """
     Converts a temperature from Celsius to Fahrenheit.
 
@@ -8,4 +8,4 @@ def to_fahrenheit(celsius):
     Returns:
         float: Temperature in Fahrenheit.
     """
-    return (celsius * 9/5) - 32
+    return (celsius * 9/5) + 32

--- a/test_temperature_conversion_0C_to_32F.py
+++ b/test_temperature_conversion_0C_to_32F.py
@@ -7,4 +7,10 @@ class TestTemperatureConverter(unittest.TestCase):
         # 
         # Note: since this is float conversion, test uses AlmostEqual assertion
         # to make sure that rounding errors are not counted as errors 
-        self.assertAlmostEqual(to_fahrenheit(0), 32, delta=1e-9)
+        self.assertAlmostEqual(to_fahrenheit(0), 32, places=5)
+    def test_hundred_celcius(self):
+        # Checks if 100C is converted correctly into 212F
+        self.assertAlmostEqual(to_fahrenheit(100), 212, places=5)
+    def test_negative_forty(self):
+        # Checks if -40C is converted correctly into -40F
+        self.assertAlmostEqual(to_fahrenheit(-40), -40, places=5)

--- a/test_temperature_conversion_0C_to_32F.py
+++ b/test_temperature_conversion_0C_to_32F.py
@@ -1,0 +1,10 @@
+import unittest
+from temperature_utils import to_fahrenheit
+
+class TestTemperatureConverter(unittest.TestCase):
+    def test_zero_celsius(self):
+        # Checks if 0C is correctly converted to 32F.
+        # 
+        # Note: since this is float conversion, test uses AlmostEqual assertion
+        # to make sure that rounding errors are not counted as errors 
+        self.assertAlmostEqual(to_fahrenheit(0), 32, delta=1e-9)

--- a/test_temperature_utils.py
+++ b/test_temperature_utils.py
@@ -7,5 +7,19 @@ class TestTemperatureUtils(unittest.TestCase):
         result = to_fahrenheit(100)
         self.assertIsInstance(result, float)
 
+    def test_zero_celsius(self):
+        # Checks if 0C is correctly converted to 32F.
+        # 
+        # Note: since this is float conversion, test uses AlmostEqual assertion
+        # to make sure that rounding errors are not counted as errors 
+        self.assertAlmostEqual(to_fahrenheit(0), 32, places=5)
+    
+    def test_hundred_celcius(self):
+        # Checks if 100C is converted correctly into 212F
+        self.assertAlmostEqual(to_fahrenheit(100), 212, places=5)
+
+    def test_negative_forty(self):
+        # Checks if -40C is converted correctly into -40F
+        self.assertAlmostEqual(to_fahrenheit(-40), -40, places=5)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix the bug in the issue regarding 0C incorrectly converted into -32F
using `to_fahrenheit()` function in temperature_utils.py file. Change
the calculation formula and add type specification for input and output of
`to_fahrenheit()` function

Create test_temperature_conversion_0C_to_32F.py python unittest file, the
assertion of 0C converted to 32F correctly