### PR TITLE
Issue #54 NameCombiner Fix

### DIFF
--- a/name_combiner.py
+++ b/name_combiner.py
@@ -9,4 +9,11 @@ def combine_names(first, last):
     Returns:
         str: The full name string.
     """
-    return first + last
+    if first and last:
+        return first + " " + last
+    elif first:
+        return first
+    elif last:
+        return last
+    else:
+        return ""

--- a/test_name_combiner.py
+++ b/test_name_combiner.py
@@ -7,6 +7,9 @@ class TestNameCombiner(unittest.TestCase):
 
     def test_single_name(self):
         self.assertEqual(combine_names("Cher", ""), "Cher")
+    
+    def test_full_name(self):
+        self.assertEqual(combine_names("Andrew" ," Doser"), "Andrew Doser")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_name_combiner.py
+++ b/test_name_combiner.py
@@ -9,7 +9,7 @@ class TestNameCombiner(unittest.TestCase):
         self.assertEqual(combine_names("Cher", ""), "Cher")
     
     def test_full_name(self):
-        self.assertEqual(combine_names("Andrew" ," Doser"), "Andrew Doser")
+        self.assertEqual(combine_names("Andrew" ,"Doser"), "Andrew Doser")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The name_combiner.py program was using the + operator to combine names. This will only push the names together and not add a space. At first, I thought just adding a space between would be effective, however, it needed to have a series of if statements confirming if it was just one name, both a first and last, etc. This was able to pass all my tests.

Fixes #54 