### PR TITLE
Even Filter #55 Fix

### DIFF
--- a/even_filter.py
+++ b/even_filter.py
@@ -8,4 +8,4 @@ def get_evens(numbers):
     Returns:
         list: A list containing only the even integers from the input.
     """
-    return [n for n in numbers if n % 2 == 1]
+    return [n for n in numbers if n % 2 == 0]

--- a/test_even_filter.py
+++ b/test_even_filter.py
@@ -5,5 +5,9 @@ class TestEvenFilter(unittest.TestCase):
     def test_empty_list(self):
         self.assertEqual(get_evens([]), [])
 
+    def test_odds_and_evens(self):
+        self.assertEqual(get_evens([1, 2, 3, 4]), [2, 4])    
+
 if __name__ == '__main__':
     unittest.main()
+    


### PR DESCRIPTION
The even_filter function incorrectly returned odd numbers because of an incorrect mod condition.

The function filtered numbers using n % 2 == 1, which identifies odd numbers instead of evens.

I first added a test case with odd and even numbers to verify the function's behavior; the test
failed, demonstrating the bug in the code.

I fixed this issue by updating the mod condition to correctly identify numbers divisible by two (evens).

All tests now pass successfully.

Fixes #55.