### PR TITLE
Fix BMI calculation formula and improve test coverage

### DIFF
--- a/bmi_calculator.py
+++ b/bmi_calculator.py
@@ -11,4 +11,4 @@ def calculate_bmi(weight, height):
     Returns:
         float: The calculated BMI.
     """
-    return weight / height * height
+    return weight /( height * height)

--- a/test_bmi_calculator.py
+++ b/test_bmi_calculator.py
@@ -4,6 +4,11 @@ from bmi_calculator import calculate_bmi
 class TestBMICalculator(unittest.TestCase):
     def test_unit_dimensions(self):
         self.assertEqual(calculate_bmi(1, 1), 1)
+    def test_bigger_numbers(self):
+        #testing with 80kg and 2m
+        self.assertEqual(calculate_bmi(80, 2), 20)
+        # this checks that the output of the functio calculate_bmi, with 80 and 2 as parameters, is equal to 20
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The original code implemented the formula for BMI wrongly. This was an arithmetic error where the formula for BMI was written as weight/height * height, which is basically this: (weight/height)*height, which resulted in the
function returning weight instead of BMI.

This bug could not be caught by the provided unit test because it only contained a test case where weight and height were both 1, which would result in BMI of 1 even with the incorrect formula implemented, so the test would always pass.

To catch this bug, I added another test for when weight is 80kg and height is 2m, expecting BMI of 20.
The program failed the test, therefore exposing the bug.

To fix this bug, I changed the BMI calculation to
weight/(height * height), which is the correctly
written BMI formula. With this fix, the program passed test I added.

Fixes #48