### PR TITLE
Add test case to test_tax_adder.py to reveal bug in add_tax function and fix the bug

### DIFF
--- a/tax_adder.py
+++ b/tax_adder.py
@@ -9,4 +9,4 @@ def add_tax(subtotal, tax_rate):
     Returns:
         float: The final total.
     """
-    return subtotal * tax_rate
+    return subtotal * tax_rate + subtotal

--- a/test_tax_adder.py
+++ b/test_tax_adder.py
@@ -5,5 +5,8 @@ class TestTaxAdder(unittest.TestCase):
     def test_zero_rate(self):
         self.assertEqual(add_tax(0, 0.10), 0)
 
+    def test_more_than_subtotal(self):
+        self.assertGreaterEqual(add_tax(10, 0.30), 10)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves kevinaangstadt/CS340-S26-Repo#52

The add_tax function currently has a bug where the function returns
the tax amount instead of the total. This pull request contains two 
commits to a branch taxBugFix and resolves this bug.

The first commit modifies the file test_tax_adder.py to include a new 
test, called test_more_than_subtotal, which checks to make sure the 
return value of add_tax is greater than the subtotal, thereby indicating 
the tax has been added to the subtotal. The purpose of this test is to 
reveal the bug in add_tax where the subtotal is not added to the tax, 
and this test is created before fixing the bug to align with test-driven
development. This test is failing before the next commit.

The second commit modifies the tax_adder.py file, adding the subtotal
parameter to the return statement in tax_adder.py. This change is
made to fix the bug where add_tax was returning the tax amount
instead of the total. That test case is now passing, and will act as a 
regression test in case future maintenance reintroduces this bug.