### PR TITLE
Fix Celsius to Fahrenheit conversion formula

### DIFF
--- a/celsius_converter.py
+++ b/celsius_converter.py
@@ -8,4 +8,4 @@ def convert_to_fahrenheit(celsius):
     Returns:
         float: Temperature in Fahrenheit.
     """
-    return (celsius * 5/9) + 32
+    return (celsius * 9/5) + 32

--- a/test_celsius_converter.py
+++ b/test_celsius_converter.py
@@ -5,5 +5,9 @@ class TestCelsiusConverter(unittest.TestCase):
     def test_freezing_point(self):
         self.assertEqual(convert_to_fahrenheit(0), 32)
 
+    def test_boiling_point(self):
+        # 100 Celsius should be 212 Fahrenheit
+        self.assertEqual(convert_to_fahrenheit(100), 212)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_celsius_converter.py
+++ b/test_celsius_converter.py
@@ -3,11 +3,14 @@ from celsius_converter import convert_to_fahrenheit
 
 class TestCelsiusConverter(unittest.TestCase):
     def test_freezing_point(self):
-        self.assertEqual(convert_to_fahrenheit(0), 32)
+	# Improvement: Using assertAlmostEqual with places=2 to handle 
+	# float precision
+        self.assertAlmostEqual(convert_to_fahrenheit(0), 32, places=2)
 
     def test_boiling_point(self):
-        # 100 Celsius should be 212 Fahrenheit
-        self.assertEqual(convert_to_fahrenheit(100), 212)
+        # 100 Celsius should be 212 Fahrenheit with places=2 to handle
+	# float precision
+        self.assertAlmostEqual(convert_to_fahrenheit(100), 212, places=2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The original formula in celsius_converter.py was incorrect, which caused the temperature conversion to return the wrong values. I have updated the code to use the correct Celsius to Fahrenheit formula: (Celsius * 9/5) + 32. I also added a unit test for the boiling point (100C) to confirm the function now returns the correct result (212F). This fixes #28