### PR TITLE
Fix rectangle geometry bug

### DIFF
--- a/rectangle_geometry.py
+++ b/rectangle_geometry.py
@@ -9,4 +9,5 @@ def calculate_perimeter(length, width):
     Returns:
         float: The perimeter.
     """
-    return length + width
+    return (length + width) * 2
+    

--- a/test_rectangle_geometry.py
+++ b/test_rectangle_geometry.py
@@ -4,6 +4,9 @@ from rectangle_geometry import calculate_perimeter
 class TestRectangleGeometry(unittest.TestCase):
     def test_zero_dimensions(self):
         self.assertEqual(calculate_perimeter(0, 0), 0)
+    def test_perimeter_basic(self):
+        self.assertEqual(calculate_perimeter(3, 4), 14)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes an incorrect implementation of the rectangle geometry function.

The function returned Length + Width before fixing, updated function to return (length + width) * 2

I added a new test that initially failed to expose the bug, and then correctly ran after fixing the function.

This fixes issue: #33 