### PR TITLE
Fix case sensitivity bug in DNA transcription

### DIFF
--- a/dna_transcriber.py
+++ b/dna_transcriber.py
@@ -10,4 +10,4 @@ def transcribe_dna(dna_string):
     Returns:
         str: The corresponding RNA sequence.
     """
-    return dna_string.replace('T', 'U')
+    return dna_string.upper().replace('T', 'U')

--- a/test_dna_transcriber.py
+++ b/test_dna_transcriber.py
@@ -8,5 +8,8 @@ class TestDNATranscriber(unittest.TestCase):
     def test_no_t(self):
         self.assertEqual(transcribe_dna("CGCA"), "CGCA")
 
+    def test_lowercase_input(self):
+        self.assertEqual(transcribe_dna("gattaca"), "GAUUACA")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix
The transcriber previously didn't allow lowercase input, returning the string unchanged. This change ensures all input is normalized to uppercase before processing so that 't' is correctly converted to 'U'.

Testing 
I have added a new test case to test_dna_transcriber.py that targets lowercase input. This test reveals the bug by demonstrating that lowercase 't' was not being transcribed. After implementing the fix, this test now passes.
Fixes #43
