### PR TITLE
Fix cart total accumulation bug and add failing test

### DIFF
--- a/shopping_cart.py
+++ b/shopping_cart.py
@@ -10,5 +10,5 @@ def calculate_total(item_prices):
     """
     total = 0
     for price in item_prices:
-        total = price
+        total += price
     return total

--- a/test_shopping_cart.py
+++ b/test_shopping_cart.py
@@ -8,5 +8,8 @@ class TestShoppingCart(unittest.TestCase):
     def test_empty_cart(self):
         self.assertEqual(calculate_total([]), 0)
 
+    def test_multiple_items_sum(self):
+        self.assertEqual(calculate_total([10, 20, 30]), 60)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request addresses issue #47 involving incorrect cart total
calculation.

The calculate_total function previously overwrote the running total
during iteration:

for price in item_prices:
    total = price

Because of this, the function returned only the last item price
instead of the sum of all items in the cart. For example,
calculate_total([10, 20, 30]) returned 30 instead of 60.

This PR includes:
- A new unit test (test_multiple_items_sum) that demonstrates the bug.
The test fails with the original implementation.
- A fix that correctly accumulates prices using total += price
instead of overwriting the total.

After the change, all existing tests pass, and the new test verifies
that the function correctly computes the total for multiple items.

Fixes #47.