### PR TITLE
Bug fix

### DIFF
--- a/Day9_File_Counts.md
+++ b/Day9_File_Counts.md
@@ -1,0 +1,37 @@
+# Day 9 File Counts
+
+Task: submit a PR with the number of files contained in your home directory
+(recursively). Add your count to the table below.
+
+| Name     | File Count |
+| -------- | ---------- |
+| Alex     |            |
+| Andraz   |            |
+| Andrew   |            |
+| Andrey   |            |
+| Ariana   |            |
+| Chris    |            |
+| Chris    |            |
+| Foster   |            |
+| George   |            |
+| Georgios |            |
+| Gunnar   |            |
+| Harper   |            |
+| Honey    |            |
+| Hunter   |            |
+| Jack     |            |
+| Justin   |            |
+| Keady    |            |
+| Lala     |            |
+| Leon     |            |
+| Luke     |            |
+| Manti    |            |
+| Mary     |            |
+| MJ       |            |
+| Nikolai  |            |
+| Njeri    |            |
+| Oakley   |            |
+| Oliver   |            |
+| Siadhal  |            |
+| Spencer  |            |
+| Thomas   |            |

--- a/Day9_File_Counts.md
+++ b/Day9_File_Counts.md
@@ -31,7 +31,7 @@ Task: submit a PR with the number of files contained in your home directory
 | Nikolai  |            |
 | Njeri    |            |
 | Oakley   |            |
-| Oliver   |            |
+| Oliver   | 3995       |
 | Siadhal  |            |
 | Spencer  |            |
 | Thomas   |            |

--- a/rectangle_geometry.py
+++ b/rectangle_geometry.py
@@ -9,4 +9,4 @@ def calculate_perimeter(length, width):
     Returns:
         float: The perimeter.
     """
-    return length + width
+    return 2 * (length + width)

--- a/test_rectangle_geometry.py
+++ b/test_rectangle_geometry.py
@@ -5,5 +5,8 @@ class TestRectangleGeometry(unittest.TestCase):
     def test_zero_dimensions(self):
         self.assertEqual(calculate_perimeter(0, 0), 0)
 
+    def test_nonzero_dimensions(self):
+        self.assertEqual(calculate_perimeter(3, 4), 14)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix rectangle_geometry.py method so it returns the correct
     perimeter and add a test
    
    In this commit I add a test to test_rectangle_geometry.py that
    verifies that the perimeter is calculated correctly for a
    rectangle with a nonzero perimeter. Next I modify the code in
    rectangle_geometry.py so that it will pass this test. The bug
    that I found was that it was only adding the length of one of the
    base sides and one of the hight sides resulting in it calculating
    half of the perimeter. To fix it, I multiply this value by 2.