### PR TITLE
Fix: update threshold to be inclusive at $50

### DIFF
--- a/shipping_calculator.py
+++ b/shipping_calculator.py
@@ -12,6 +12,6 @@ def calculate_shipping(total_price):
     Returns:
         float: The shipping cost.
     """
-    if total_price > 50:
+    if total_price >= 50:
         return 0
     return 10

--- a/test_shipping_calculator.py
+++ b/test_shipping_calculator.py
@@ -8,5 +8,9 @@ class TestShippingCalculator(unittest.TestCase):
     def test_free_shipping(self):
         self.assertEqual(calculate_shipping(60), 0)
 
+    def test_edge_case_shipping(self):
+        self.assertEqual(calculate_shipping(50), 0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_shipping_calculator.py
+++ b/test_shipping_calculator.py
@@ -11,6 +11,8 @@ class TestShippingCalculator(unittest.TestCase):
     def test_edge_case_shipping(self):
         self.assertEqual(calculate_shipping(50), 0)
 
+    def test_just_below_free_shipping(self):
+        self.assertEqual(calculate_shipping(49.99), 10)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #31

The **issue** within shipping_calculator.py is directly related to an edge
case where the final price of the order equals exactly the free shipping
threshold ($50). The current implementation uses "> 50", which means an
order of exactly $50 is **incorrectly charged for shipping**.

Adjust the comparison operator from ">" to ">=" to ensure that orders
totaling exactly $50 receive free shipping. This change aligns with the
intended business logic and ensures that customers are not unfairly
charged for shipping on qualifying orders.

Add a new unit test in test_shipping_calculator.py that passes an order
total of exactly $50.00 to reveal the bug. Verify that this test fails
under the old logic and passes with the updated threshold, while all
other existing tests still pass.