### PR TITLE
Fix median calculation for unsorted lists

### DIFF
--- a/median_finder.py
+++ b/median_finder.py
@@ -10,5 +10,9 @@ def find_median(numbers):
     Returns:
         float: The median value.
     """
-    middle_index = len(numbers) // 2
-    return numbers[middle_index]
+
+    sort = sorted(numbers);
+
+    middle_index = len(sort) // 2
+
+    return sort[middle_index]

--- a/test_median_finder.py
+++ b/test_median_finder.py
@@ -8,5 +8,11 @@ class TestMedianFinder(unittest.TestCase):
     def test_longer_sorted_list(self):
         self.assertEqual(find_median([10, 20, 30, 40, 50]), 30)
 
+    def test_unsorted_list(self):
+        self.assertEqual(find_median([3, 1, 2]), 2)
+
+    def test_longer_unsorted_list(self):
+        self.assertEqual(find_median([3, 2, 4, 1, 3]), 3)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Summary:
The previous implementation returned the middle element,
even if the list is unsorted. This produced incorrect results
for unsorted inputs.

Tests Added:
- Unsorted odd-length list (e.g., [3, 1, 2])

Fix:
The updated code creates a copy of the original list to avoid 
mutating the original list. We then sort the list and store it in 
a variable. Finally, we return the number in the middle of the
sorted list to get the median.

Fixes #38