### PR TITLE
Fix Bug #46: Make vowel counting insensitive to capitalization

### DIFF
--- a/test_vowel_counter.py
+++ b/test_vowel_counter.py
@@ -8,5 +8,8 @@ class TestVowelCounter(unittest.TestCase):
     def test_no_vowels(self):
         self.assertEqual(count_vowels("rhythm"), 0)
 
+    def test_all_vowels(self):
+        self.assertEqual(count_vowels("AEIOU"), 5)
+
 if __name__ == '__main__':
     unittest.main()

--- a/vowel_counter.py
+++ b/vowel_counter.py
@@ -12,6 +12,6 @@ def count_vowels(text):
     """
     count = 0
     for char in text:
-        if char in "aeiou":
+        if char.lower() in "aeiou":
             count += 1
     return count


### PR DESCRIPTION
Change characters to lower-case before checking them with vowels (a,e,i,o,u). 
Initially the upper-case letters were not being counted as vowels 'A' does not 
equal 'a' in Python and the condition only checked for uncapitalized vowels

- Use .lower() to each character to uncapitalize letters and compare
- Add test case using "AEIOU" as an argument to reveal the bug

Fixes #46 