### PR TITLE
Fix bug #53 range function logic and add failing test

### DIFF
--- a/countdown_generator.py
+++ b/countdown_generator.py
@@ -8,4 +8,5 @@ def generate_countdown(start):
     Returns:
         list: A list of integers counting down to 0.
     """
-    return list(range(start, 0, -1))
+    # return list(range(start, 0, -1))
+    return list(range(start, -1, -1))

--- a/test_countdown_generator.py
+++ b/test_countdown_generator.py
@@ -5,5 +5,11 @@ class TestCountdownGenerator(unittest.TestCase):
     def test_start_one(self):
         self.assertEqual(generate_countdown(1)[0], 1)
 
+    # This test checks for the last index of the list
+    # and checks if the last index is 0
+    def test_for_zero(self): 
+        self.assertEqual(generate_countdown(5)[-1], 0)
+        
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The range function in this code has a logic error. Python's documentation of the range function is range(start, stop, step) where start is inclusive, stop is exclusive. The original code was range(start, 0, -1) so the countdown was missing 0 in the list because it's excluded from the list. To fix this, I changed 0 to -1 so 0 would be included in the countdown sequence.

In addition, I added another test to check if the last index of the countdown list ([-1]) was equal to 0. The initial test only checked for the first index of the list and tested if it was equal to the start number given. The added test catches a missing 0 if the number in the last index is not equal to 0.