### PR TITLE
Fix bug in grade passer

### DIFF
--- a/grade_passer.py
+++ b/grade_passer.py
@@ -8,4 +8,4 @@ def is_passing(grade):
     Returns:
         bool: True if the grade is passing, False otherwise.
     """
-    return grade > 60
+    return grade >= 60

--- a/test_grade_passer.py
+++ b/test_grade_passer.py
@@ -8,5 +8,9 @@ class TestGradePasser(unittest.TestCase):
     def test_failing_score(self):
         self.assertFalse(is_passing(40))
 
+    #Test case for the reported bug of a score of 60 being considered failing when it should pass
+    def test_bug_score(self):
+        self.assertTrue(is_passing(60))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes issue with the grade passer function returning false when a grade of exactly 60 was entered. The
issue was fixed by making the number 60 included. Grades of 60 now work as intended and are able to 
pass. 

A test file was also added that finds the bug and checks the value of 60 which expects true as the output. 
The bug was confirmed and after the fix is able to pass all tests. 

Fixes [#19].