### PR TITLE
Max finder failure on lists with only negatives

### DIFF
--- a/list_max_finder.py
+++ b/list_max_finder.py
@@ -8,7 +8,7 @@ def find_max(numbers):
     Returns:
         float: The maximum value found in the list.
     """
-    max_val = 0
+    max_val = numbers[0]
     for n in numbers:
         if n > max_val:
             max_val = n

--- a/list_max_finder.py
+++ b/list_max_finder.py
@@ -8,6 +8,10 @@ def find_max(numbers):
     Returns:
         float: The maximum value found in the list.
     """
+
+    if len(numbers) == 0:
+    	return None
+
     max_val = numbers[0]
     for n in numbers:
         if n > max_val:

--- a/test_list_max_finder.py
+++ b/test_list_max_finder.py
@@ -8,5 +8,8 @@ class TestListMaxFinder(unittest.TestCase):
     def test_mixed_numbers(self):
         self.assertEqual(find_max([-10, 5, 2]), 5)
 
+    def test_all_negative_numbers(self):
+        self.assertEqual(find_max([-5,-2,-9,-11]),-2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_list_max_finder.py
+++ b/test_list_max_finder.py
@@ -1,6 +1,7 @@
 import unittest
 from list_max_finder import find_max
 
+
 class TestListMaxFinder(unittest.TestCase):
     def test_positive_numbers(self):
         self.assertEqual(find_max([1, 5, 2]), 5)
@@ -9,7 +10,11 @@ class TestListMaxFinder(unittest.TestCase):
         self.assertEqual(find_max([-10, 5, 2]), 5)
 
     def test_all_negative_numbers(self):
-        self.assertEqual(find_max([-5,-2,-9,-11]),-2)
+        self.assertEqual(find_max([-5, -2, -9, -11]), -2)
+
+    def test_empty_list(self):
+        self.assertEqual(find_max([]), None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request fixes issue 36, where the max finder was having issues with a list with only negative numbers. This occurred because it was taking 0 as the initial case, so when all numbers are negative, 0 would be the max when it was actually some negative number.

I added a test for the bug by giving it all negative numbers. I then changed the initial case to be the first number in the list instead of 0, so that the maximum can be a negative number. The new test failed before implementing my change, but passed after, and the full test suite also passed.

Fix #36