### PR TITLE
Fix power calculation and add test case

### DIFF
--- a/power_calculator.py
+++ b/power_calculator.py
@@ -9,4 +9,4 @@ def calculate_power(base, exponent):
     Returns:
         float: The result of base ^ exponent.
     """
-    return base * exponent
+    return base ** exponent

--- a/test_power_calculator.py
+++ b/test_power_calculator.py
@@ -8,5 +8,8 @@ class TestPowerCalculator(unittest.TestCase):
     def test_power_of_one(self):
         self.assertEqual(calculate_power(5, 1), 5)
 
+    def test_power_of_cubed(self):
+        self.assertEqual(calculate_power(3, 3), 27)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The calculate_power function was incorrectly using a multiplication 
operator (*) instead of using the exponent operator (**).
This caused the function to multiply the two
given numbers rather than raising the first number to the power of the 
second number. A test case was added to verify 3^3 equals 27. I also
came to the realization that I need to change the name of 
my function from test_power_of_one to test_power_of_cubed.

Fixes #45