### PR TITLE
Fix bug for age classifier

### DIFF
--- a/age_classifier.py
+++ b/age_classifier.py
@@ -9,13 +9,12 @@ def classify_age(age):
 
     Args:
         age (int): The age in years.
-
     Returns:
         str: The classification ('Child', 'Teen', or 'Adult').
     """
     if age < 13:
         return "Child"
-    elif age < 19:
+    elif age <= 19:
         return "Teen"
     else:
         return "Adult"

--- a/test_age_classifier.py
+++ b/test_age_classifier.py
@@ -10,6 +10,9 @@ class TestAgeClassifier(unittest.TestCase):
 
     def test_adult(self):
         self.assertEqual(classify_age(25), "Adult")
+    
+    def test_nineteen(self):
+        self.assertEqual(classify_age(19), "Teen")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The original code had for the age classifier had a syntax error
 as it incorrectly had age < 19 toreturn a string "Teen". This bug
 wasn't caught because the ages being tested, where all in the
 correct bounds. But when you tested 19 and tried to classify it
 as a teen, an error  would appear. In order to correct this bug
 you change the syntax from age < to  age <= 19 as it would include
 nineteen to be a teen instead of a adult.