### PR TITLE
Fix case-sensitive palindrome check

### DIFF
--- a/palindrome_checker.py
+++ b/palindrome_checker.py
@@ -8,4 +8,4 @@ def is_palindrome(word):
     Returns:
         bool: True if it is a palindrome, False otherwise.
     """
-    return word == word[::-1]
+    return word.lower() == word[::-1].lower()

--- a/test_palindrome_checker.py
+++ b/test_palindrome_checker.py
@@ -7,6 +7,12 @@ class TestPalindromeChecker(unittest.TestCase):
 
     def test_non_palindrome(self):
         self.assertFalse(is_palindrome("hello"))
+    
+    def test_upper_palindrome(self):
+        self.assertTrue(is_palindrome("Bob"))
+    
+    def test_upper_non_palindrome(self):
+        self.assertFalse(is_palindrome("Bobby"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Issue

Checking if a word is a palindrome fails if the word has capitalization.

## Test

Added 1 test for a palindrome with the first letter capitalized.
Added 1 test for a non-palindrome with the first letter capitalized

## Fix

Set the comparison to lowercase so case does not change the output.

Fixes #29 