### PR TITLE
Word Count counting spaces bug fix.

### DIFF
--- a/test_word_counter.py
+++ b/test_word_counter.py
@@ -8,5 +8,8 @@ class TestWordCounter(unittest.TestCase):
     def test_single_word(self):
         self.assertEqual(count_words("Python"), 1)
 
+    def test_two_space(self):
+        self.assertEqual(count_words("Hello  world"), 2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/word_counter.py
+++ b/word_counter.py
@@ -8,4 +8,4 @@ def count_words(sentence):
     Returns:
         int: The number of words.
     """
-    return len(sentence.split(" "))
+    return len(sentence.split())


### PR DESCRIPTION
The original code had a bug that caused it to count spaces extra spaces as words. This means that if the string was "Hello  world" with 2 spaces, it would return a word count of 3. This bug wasn't caught because the test file didn't have a test for two spaces. This was happening because it was splitting on a space instead of splitting between words. After fixing this, it passes the test with two spaces. 