### PR TITLE
Issue 16 fix

### DIFF
--- a/average_calculator.py
+++ b/average_calculator.py
@@ -8,5 +8,8 @@ def calculate_average(numbers):
     Returns:
         float: The average value of the list.
     """
+    # Handle the case of an empty list to avoid division by zero
+    if not numbers:
+        return 0
     total = sum(numbers)
     return total / len(numbers)

--- a/test_average_calculator.py
+++ b/test_average_calculator.py
@@ -8,5 +8,8 @@ class TestAverageCalculator(unittest.TestCase):
     def test_average_floats(self):
         self.assertEqual(calculate_average([1.5, 2.5, 3.5]), 2.5)
 
+    def test_average_empty_list(self):
+        self.assertEqual(calculate_average([]), 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Issue #16 indicates that `average_calculator.py` fails when there is an empty list provided.

I added one test case to check that an empty list returns 0.

Then, I fixed the code by adding a check for an empty list, which returns 0.