### PR TITLE
Fix: Correct logic in apply_discount to return final price 

### DIFF
--- a/discount_applier.py
+++ b/discount_applier.py
@@ -9,4 +9,4 @@ def apply_discount(price, discount_percentage):
     Returns:
         float: The price after the discount is applied.
     """
-    return price * discount_percentage
+    return price * (1 - discount_percentage)

--- a/test_discount_applier.py
+++ b/test_discount_applier.py
@@ -4,6 +4,9 @@ from discount_applier import apply_discount
 class TestDiscountApplier(unittest.TestCase):
     def test_fifty_percent_discount(self):
         self.assertEqual(apply_discount(100, 0.5), 50.0)
+    
+    def test_twenty_percent_discount(self):
+        self.assertEqual(apply_discount(200, 0.2), 160.0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Resolves #17

Previously, the `apply_discount` function was
incorrectly returning the calculated discount
amount (e.g., $20) rather than the final price
after the discount (e.g., $80). This bug was
masked in scenarios where a 50% discount was
applied, as the discount amount and the final
price happened to be identical.

Changes:
* Updated `discount_applier.py` to calculate the final price using the formula: $$price \times (1 - discount\_percentage)$$
* Added a new test case in `test_discount_applier.py` for a 20% discount to validate the fix and ensure future regressions are caught.

Logic Breakdown:
* **Original (Incorrect):** Calculated the "portion taken off." Example: $100 \times 0.20 = 20$
* **New (Correct):** Calculates the "remaining balance." Example: $100 \times (1 - 0.20) = 80$