### PR TITLE
Support repeating string with a negative count

### DIFF
--- a/string_repeater.py
+++ b/string_repeater.py
@@ -11,4 +11,6 @@ def repeat_string(s, n):
     Returns:
         str: The repeated (or reversed) string.
     """
+    if n < 0:
+        return s[::-1]
     return s * n

--- a/test_string_repeater.py
+++ b/test_string_repeater.py
@@ -7,6 +7,9 @@ class TestStringRepeater(unittest.TestCase):
 
     def test_repeat_zero(self):
         self.assertEqual(repeat_string("ha", 0), "")
+    
+    def test_repeat_negative(self):
+        self.assertEqual(repeat_string("ha", -1), "ah")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When `repeat_string` is called with a negative
count, it will now return the input string
reversed instead of an empty string. This allows
for more flexible behavior when handling edge
cases.