### PR TITLE
Use os.path.join for robust file path construction

### DIFF
--- a/file_path_builder.py
+++ b/file_path_builder.py
@@ -1,3 +1,5 @@
+import os
+
 def build_path(folder, filename):
     """
     Constructs a file path from a folder and filename.
@@ -9,4 +11,4 @@ def build_path(folder, filename):
     Returns:
         str: The full path combined correctly.
     """
-    return folder + filename
+    return os.path.join(folder, filename)

--- a/test_file_path_builder.py
+++ b/test_file_path_builder.py
@@ -4,6 +4,9 @@ from file_path_builder import build_path
 class TestFilePathBuilder(unittest.TestCase):
     def test_path_with_slash(self):
         self.assertEqual(build_path("/home/user/", "doc.txt"), "/home/user/doc.txt")
+    
+    def test_path_without_slash(self):
+        self.assertEqual(build_path("/home/user", "file.txt"), "/home/user/file.txt")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, `build_path` used simple string concatenation (`folder + filename`). This caused incorrect paths when the `folder` argument did not end with a trailing slash, resulting in merged directory and file names.

Changes:
* Refactored `build_path` to use `os.path.join()`, ensuring the appropriate OS-specific directory separator is used.
* Added a new test case `test_path_without_slash` to verify that paths are correctly joined even when the trailing slash is missing from the input.

Logic Breakdown:
* **Old Logic:** `"/home/user" + "file.txt"` -> `"/home/userfile.txt"` (Broken)
* **New Logic:** `os.path.join("/home/user", "file.txt")` -> `"/home/user/file.txt"` (Correct)