### PR TITLE
Fix issue #49, list double

### DIFF
--- a/list_doubler.py
+++ b/list_doubler.py
@@ -8,4 +8,8 @@ def double_elements(numbers):
     Returns:
         list: A new list with each element multiplied by 2.
     """
-    return numbers * 2
+
+
+    return [i * 2 for i in numbers]
+        
+

--- a/test_list_doubler.py
+++ b/test_list_doubler.py
@@ -5,5 +5,8 @@ class TestListDoubler(unittest.TestCase):
     def test_zero_element(self):
         self.assertEqual(double_elements([]), [])
 
+    def test_correct_double(self):
+        self.assertEqual(double_elements([1,2]), [2,4])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Issue
- double_elements returned values appended to the end of list instead of multiplying the original values

## Solution
- revised to a list comprehension to iterate and multiply individually

## Testing
- test_correct_double shows typical behavior if the elements are multiplied rather than duplicated