### PR TITLE
Fix csv newline

### DIFF
--- a/csv_stripper.py
+++ b/csv_stripper.py
@@ -8,4 +8,4 @@ def parse_csv_line(line):
     Returns:
         list: A list of values extracted from the line.
     """
-    return line.split(",")
+    return line.strip("\n").split(",")

--- a/test_csv_stripper.py
+++ b/test_csv_stripper.py
@@ -6,5 +6,9 @@ class TestCSVStripper(unittest.TestCase):
         result = parse_csv_line("a,b,c")
         self.assertEqual(len(result), 3)
 
+    def test_newline_stripped(self):
+        result = parse_csv_line("a,b,c\n")
+        self.assertEqual(result[-1], "c")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #56

When parsing a CSV line that contains a trailing newline character, 
the last element in the returned list incorrectly included the newline 
("c\n" instead of "c"). This was caused by splitting the raw line 
without first stripping the newline character. This PR adds a test that 
reveals the bug and fixes parse_csv_line() by calling line.strip("\n") 
on the input before splitting on commas.