### PR TITLE
Update test_color_converter.py

### DIFF
--- a/test_color_converter.py
+++ b/test_color_converter.py
@@ -4,9 +4,37 @@ from color_converter import rgb_to_hex
 class TestColorConverter(unittest.TestCase):
     def test_white(self):
         self.assertEqual(rgb_to_hex(255, 255, 255), "#ffffff")
-
+    #added three zeros to check for leading zeros
     def test_black(self):
-        self.assertEqual(rgb_to_hex(0, 0, 0), "#000") 
+        self.assertEqual(rgb_to_hex(0, 0, 0), "#000000") 
+
+ #added tests   
+    #checking if output where r and g are less than 16 includes leading 0s
+    def test_rg_16(self):
+        self.assertEqual(rgb_to_hex(8, 12, 31), "#080c1f")
+
+    #checking if output where g and b are less than 16 includes leading 0s
+    def test_gb_16(self):
+        self.assertEqual(rgb_to_hex(31, 15, 8), "#1f0f08")
+
+    #checking if output where r and b are less than 16 includes leading 0s
+    def test_rb_16(self):
+        self.assertEqual(rgb_to_hex(10, 255, 3), "#0aff03")
+
+
+    #checking if output where only r is less than 16 includes leading 0s
+    def test_r_16(self):
+        self.assertEqual(rgb_to_hex(8, 255, 255), "#08ffff")
+
+    #checking if output where only g is less than 16 includes leading 0s
+    def test_g_16(self):
+        self.assertEqual(rgb_to_hex(255, 3, 255), "#ff03ff")
+
+    #checking if output where only b is less than 16 includes leading 0s
+    def test_g_16(self):
+        self.assertEqual(rgb_to_hex(255, 255, 10), "#ffff0a")
+        
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added tests for suggested changes to the color)converter.py function to fix the issue of leading zeros being not included in the output. Specifically checks that the leading zeros are included for the following ranges:

- modified test_black to test this: r <= 15 and g <=15 and b <=15
-  r <= 15 and g <=15 and b > 15 (only r and g need leading zeros)
-  r > 15 and g <=15 and b <=15 (only g and b needing leading zeros)
-  r <= 15 and g >15 and b <=15 (only r and b need leading zeros)
-  r <= 15 and g >15 and b >15 (only r needs a leading zero)
-  r >15 and g <=15 and b >15 (only g needs a leading zero)
- r > 15 and g >15 and b <=15 (only b needs a leading zero)

I think I managed to add a test for every if statement suggested for the main code and the range of each one.